### PR TITLE
Installing Radamsa

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -343,6 +343,13 @@ RUN \
     curl -L -o all.txt https://gist.githubusercontent.com/jhaddix/86a06c5dc309d08580a018c66354a056/raw/96f4e51d96b2203f19f6381c8c545b278eaa0837/all.txt && \
     curl -L -o fuzz.txt https://raw.githubusercontent.com/Bo0oM/fuzz.txt/master/fuzz.txt
 
+# Installing Radamsa (to create mutational fuzzers)
+RUN \ 
+    git clone https://gitlab.com/akihe/radamsa.git && \
+    cd radamsa && \
+    make && \
+    make install
+
 # WORDLIST
 FROM builder2 as builder3
 COPY --from=wordlist /temp/ /tools/wordlist/


### PR DESCRIPTION
Added the capability to install Radamsa. Radamsa is a test case generator for robustness testing. It is typically used to test how well a program can withstand malformed and potentially malicious inputs. It works by reading sample files of valid data and generating interestingly different outputs from them. The main selling points of `radamsa` are that it has already found a slew of bugs in programs that actually matter, it is easily scriptable and, easy to get up and running.